### PR TITLE
add support for "invisible" directories

### DIFF
--- a/packages/arc-resolver/test.js
+++ b/packages/arc-resolver/test.js
@@ -53,6 +53,42 @@ describe('Resolver', () => {
       ]);
     });
 
+    it('should resolve multiple levels invisible dirs', () => {
+      // setup
+      let fs = new MemoryFS();
+      let resolver = new Resolver(fs);
+      fs.mkdirpSync('/locales/[en]');
+      fs.mkdirpSync('/locales/[US]/[en]');
+      fs.mkdirpSync('/locales/[CA]/[en]');
+      fs.mkdirpSync('/locales/[CA]/[fr]');
+      fs.writeFileSync('/locales/[en]/sample.properties', 'contents');
+      fs.writeFileSync('/locales/[US]/[en]/sample.properties', 'contents');
+      fs.writeFileSync('/locales/[CA]/[en]/sample.properties', 'contents');
+      fs.writeFileSync('/locales/[CA]/[fr]/sample.properties', 'contents');
+
+      //test
+      let filepath = '/locales/sample.properties';
+      let matches = resolver.getMatchesSync(filepath);
+      expect(matches.raw).to.eql([
+        {
+          flags: ['US', 'en'],
+          value: '/locales/[US]/[en]/sample.properties'
+        },
+        {
+          flags: ['CA', 'en'],
+          value: '/locales/[CA]/[en]/sample.properties'
+        },
+        {
+          flags: ['CA', 'fr'],
+          value: '/locales/[CA]/[fr]/sample.properties'
+        },
+        {
+          flags: ['en'],
+          value: '/locales/[en]/sample.properties'
+        }
+      ]);
+    });
+
     it('should cache for better perf', () => {
       // setup
       let fs = new MemoryFS();

--- a/packages/arc-server/test/index.js
+++ b/packages/arc-server/test/index.js
@@ -128,6 +128,22 @@ describe('AdaptiveRequireHook', () => {
     });
   });
 
+  describe('invisible directories', () => {
+    it('should resolve adaptive files', function() {
+      arc.setFlagsForContext(['desktop'], () => {
+        let proxy = require('./invisible-directories');
+        expect(proxy.test()).to.equal('component/desktop');
+      });
+    });
+
+    it('should resolve adaptive files', function() {
+      arc.setFlagsForContext(['mobile', 'ios'], () => {
+        let proxy = require('./invisible-directories');
+        expect(proxy.test()).to.equal('component/mobile.ios');
+      });
+    });
+  });
+
   describe('primitives', () => {
     it('should resolve adaptive files', function() {
       let primitive = require('./primitives');

--- a/packages/arc-server/test/invisible-directories/[desktop]/index.js
+++ b/packages/arc-server/test/invisible-directories/[desktop]/index.js
@@ -1,0 +1,1 @@
+exports.test = () => 'component/desktop';

--- a/packages/arc-server/test/invisible-directories/[mobile]/[android]/index.js
+++ b/packages/arc-server/test/invisible-directories/[mobile]/[android]/index.js
@@ -1,0 +1,1 @@
+exports.test = () => 'component/mobile.android';

--- a/packages/arc-server/test/invisible-directories/[mobile]/[ios]/index.js
+++ b/packages/arc-server/test/invisible-directories/[mobile]/[ios]/index.js
@@ -1,0 +1,1 @@
+exports.test = () => 'component/mobile.ios';

--- a/packages/arc-server/test/invisible-directories/[mobile]/index.js
+++ b/packages/arc-server/test/invisible-directories/[mobile]/index.js
@@ -1,0 +1,1 @@
+exports.test = () => 'component/mobile';


### PR DESCRIPTION
Updates the resolution logic to treat directories whose name is only a flag expression as "invisible".

**Example**

This:
- `locales/[en]/foo.json`
- `locales/[de]/foo.json`

Is equivalent to:
- `locales/foo[en].json`
- `locales/foo[de].json`

**Another Example**

It also works with multiple levels. This:
- `locales/[en]/foo.json`
- `locales/[CA]/[en]/foo.json`
- `locales/[CA]/[fr]/foo.json`

Is equivalent to:
- `locales/foo[en].json`
- `locales/foo[CA+en].json`
- `locales/foo[CA+fr].json`



In both examples, you can request `locales/foo.json` as if the flagged directories didn't exist.