### PR TITLE
Virtual module support

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,5 +3,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "2.0.0-alpha.6"
+  "version": "2.0.0-alpha.7"
 }

--- a/packages/arc-webpack/index.js
+++ b/packages/arc-webpack/index.js
@@ -13,25 +13,67 @@ class AdaptivePlugin {
   apply(compiler) {
     let fs = compiler.inputFileSystem;
     let afs = new AdaptiveFS({ fs, flags: this.flags });
-    compiler.inputFileSystem = afs;
-    if (this.proxy) {
-      compiler.hooks.normalModuleFactory.tap("arc", normalModuleFactory => {
-        normalModuleFactory.hooks.afterResolve.tap("arc", data => {
+
+    compiler.inputFileSystem = new Proxy(afs, {
+      get(afs, property) {
+        if (afs[property]) {
+          return afs[property];
+        }
+        const value = fs[property];
+        if (typeof value === 'function') {
+          return value.bind(fs);
+        } else {
+          return value;
+        }
+      },
+      set(afs, property, value) {
+        fs[property] = value;
+      }
+    });
+
+    compiler.hooks.normalModuleFactory.tap('arc', normalModuleFactory => {
+      normalModuleFactory.hooks.afterResolve.tap('arc', data => {
+        const query = (/\?.*$/.exec(data.resource) || '')[0] || '';
+        const resource = data.resource.slice(0, query ? -query.length : undefined);
+        if (this.proxy) {
           if (data.resourceResolveData.context.issuer !== __filename) {
-            if (afs.isAdaptiveSync(data.resource)) {
-              let matches = afs.getMatchesSync(data.resource);
+            let isAdaptive;
+            try {
+              isAdaptive = afs.isAdaptiveSync(resource);
+            } catch(e) {
+              // An error may be thrown if the resource cannot be found.
+              // However this hook would not have been called if the resource
+              // could not have been resolved.  We'll assume some other plugin
+              // is making this resource available to webpack and that it's not 
+              // adaptive.
+              isAdaptive = false;
+            }
+
+            if (isAdaptive) {
+              let matches = afs.getMatchesSync(resource);
               data.loaders = [{
                 options: {
-                  matches
+                  matches,
+                  query
                 },
                 loader: proxyLoaderPath
               }];
               data.request = data.resource = __filename + '?proxy=' + data.resource;
             }
           }
-        });
+        } else {
+          try {
+            data.request = data.resource = afs.resolveSync(resource) + query;
+          } catch(e) {
+            // An error may be thrown if the resource cannot be found.
+            // However this hook would not have been called if the resource
+            // could not have been resolved.  We'll assume some other plugin
+            // is making this resource available to webpack and that it's not 
+            // adaptive.
+          }
+        }
       });
-    }
+    });
   }
 }
 

--- a/packages/arc-webpack/package.json
+++ b/packages/arc-webpack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arc-webpack",
-  "version": "2.0.0-alpha.6",
+  "version": "2.0.0-alpha.7",
   "description": "",
   "main": "index.js",
   "author": "Michael Rawlings <ml.rawlings@gmail.com>",

--- a/packages/arc-webpack/proxy-loader.js
+++ b/packages/arc-webpack/proxy-loader.js
@@ -13,12 +13,13 @@ try {
 module.exports = function(source) {
   let options = loaderUtils.getOptions(this);
   let matches = options.matches;
+  let query = options.query || '';
   let code = `
     let Proxy = require('arc-server/proxy');
     let MatchSet = require('arc-resolver').MatchSet;
     let matches = new MatchSet([${
       Array.from(matches).map(({ value, flags }) => {
-        return `{ value:require(${js(value)}), flags:${js(flags)}}`;
+        return `{ value:require(${js(value + query)}), flags:${js(flags)}}`;
       }).join(',')
     }]);
 

--- a/packages/arc-webpack/test/index.js
+++ b/packages/arc-webpack/test/index.js
@@ -78,6 +78,40 @@ describe('AdaptivePlugin', () => {
         expect(bundle).to.include(`console.log('mobile')`);
         expect(bundle).to.include(`new Proxy`);
       });
+      it('should allow things to touch the original inputFileSystem', async () => {
+        let compiler = webpack({
+          mode: 'none',
+          entry: entry,
+          output: { path: '/', filename: 'bundle.js' },
+          plugins: [
+            new AdaptivePlugin({ flags: { desktop: true } }),
+            (compiler) => {
+              const fs = compiler.inputFileSystem;
+              expect(fs.purge).to.be.a('function');
+              fs.foo = 123;
+              expect(fs.foo).to.be.equal(123);
+            }
+          ]
+        });
+        let fs = (compiler.outputFileSystem = new MemoryFS());
+        await promisify(compiler.run).call(compiler);
+        let bundle = fs.readFileSync('/bundle.js', 'utf-8');
+        expect(bundle).to.include(`console.log('desktop')`);
+        expect(bundle).to.not.include(`console.log('mobile')`);
+      });
+      
+      // it('should give a non-arc stacktrace when file is missing', async () => {
+      //   let compiler = webpack({
+      //     mode: 'none',
+      //     target: 'async-node',
+      //     entry: entry,
+      //     plugins: [new AdaptivePlugin({ proxy: true })]
+      //   });
+      //   let fs = (compiler.outputFileSystem = new MemoryFS());
+      //   let stats = await promisify(compiler.run).call(compiler);
+      //   let errors = stats.compilation.errors;
+      //   expect(errors.length).to.equal(1);
+      // });
     });
   });
 });


### PR DESCRIPTION
This PR is primarily to fix issues when using `arc-webpack` with [`webpack-virtual-modules`](https://github.com/sysgears/webpack-virtual-modules), however, it does so by making less assumptions about the input filesystem and how it will be used.

- A proxy is created to the original filesystem so that any extra methods or properties that are not handled by `arc-fs` fall through to the original filesystem
- In the `after-resolve` hook, if an error is thrown because we can't find a file in the arc filesystem, we ignore it.  If the `after-resolve` hook was called, that means webpack was able to find the file somehow, so we'll just let it pass through even though we can't adapt it.