### PR TITLE
Added support for node: prefixed built-in modules

### DIFF
--- a/packages/arc-server/install.js
+++ b/packages/arc-server/install.js
@@ -33,7 +33,11 @@ Module.prototype.require = function(request) {
 
 let coreModules;
 
-function isCoreModule(moduleName) {
+const isCoreModule = Module.isBuiltin || (moduleName => {
+  if (moduleName.startsWith('node:')) {
+    return true;
+  }
+
   if (!coreModules) {
     let coreModulesNames = Object.keys(process.binding('natives'));
     coreModules = coreModulesNames.reduce(
@@ -42,7 +46,7 @@ function isCoreModule(moduleName) {
     );
   }
   return coreModules[moduleName];
-}
+});
 
 let resolveCache = Object.create(null);
 

--- a/packages/arc-server/test/index.js
+++ b/packages/arc-server/test/index.js
@@ -107,6 +107,10 @@ describe('AdaptiveRequireHook', () => {
       require('http');
     });
 
+    it('should allow node native modules with node: prefix to pass through', () => {
+      require('node:events');
+    });
+
     it('should throw a missing module error when a module does not exist', () => {
       expect(() => require('./missing')).to.throw("Cannot find module './missing'");
     })


### PR DESCRIPTION
- Uses module.isBuiltin if it's available, otherwise it falls back to the original custom function, with some additional logic to look for the node: prefix.

Note: I wasn't sure what the minimum supported node version was, so I kept the fallback for isBuiltin.  LMK if I can ditch the fallback, or if I should handle the implementation in a different way.