### PR TITLE
Preserve proxied arrays

### DIFF
--- a/packages/arc-server/proxy.js
+++ b/packages/arc-server/proxy.js
@@ -93,17 +93,12 @@ function createAdaptiveProxy(matches, path, defaultTarget) {
         );
 
         if (descriptor && descriptor.configurable === false) {
-          if (descriptor.writable === false) {
-            descriptor.configurable = true;
-          } else {
-            const targetDescriptor = Reflect.getOwnPropertyDescriptor(
-              target,
-              property,
-            );
-            if (targetDescriptor && targetDescriptor.configurable) {
-              descriptor.configurable = true;
-            }
-          }
+          const originalTargetDescriptor = Reflect.getOwnPropertyDescriptor(
+            target,
+            property,
+          );
+          descriptor.configurable =
+            !originalTargetDescriptor || originalTargetDescriptor.configurable;
         }
 
         return descriptor;
@@ -158,7 +153,7 @@ function toConfigurable(obj) {
   let isConfigurable = Object.isExtensible(obj);
   for (const key in props) {
     const prop = props[key];
-    if (prop.configurable === false && props.writable === false) {
+    if (prop.configurable === false) {
       prop.configurable = true;
       isConfigurable = false;
     }

--- a/packages/arc-server/proxy.js
+++ b/packages/arc-server/proxy.js
@@ -142,6 +142,10 @@ function getPath(object, path) {
 }
 
 function toConfigurable(obj) {
+  if (Array.isArray(obj)) {
+    return obj
+  }
+
   const props = Object.getOwnPropertyDescriptors(obj);
   let isConfigurable = Object.isExtensible(obj);
   for (const key in props) {

--- a/packages/arc-server/test/arrays/index.js
+++ b/packages/arc-server/test/arrays/index.js
@@ -1,0 +1,1 @@
+module.exports = [1,2,3]

--- a/packages/arc-server/test/arrays/index[adapt].js
+++ b/packages/arc-server/test/arrays/index[adapt].js
@@ -1,0 +1,1 @@
+module.exports = [4,5,6];

--- a/packages/arc-server/test/index.js
+++ b/packages/arc-server/test/index.js
@@ -163,11 +163,12 @@ describe('AdaptiveRequireHook', () => {
   });
 
   describe('objects', () => {
-    it('should return non-configurable property descriptors as configurable', function() {
+    it('should return not-configurable property descriptors as configurable when also not writable', function() {
       let adaptiveValue = require('./objects');
       arc.withFlags({ config:true }, () => {
         let foo = Object.getOwnPropertyDescriptor(adaptiveValue, 'foo');
         let bar = Object.getOwnPropertyDescriptor(adaptiveValue, 'bar');
+        let baz = Object.getOwnPropertyDescriptor(adaptiveValue, 'baz');
         let missing = Object.getOwnPropertyDescriptor(adaptiveValue, 'missing');
         expect(foo).to.eql({
           value: 1,
@@ -178,6 +179,12 @@ describe('AdaptiveRequireHook', () => {
         expect(bar).to.eql({
           value: 2,
           writable: false,
+          enumerable: false,
+          configurable: true
+        });
+        expect(baz).to.eql({
+          value: 3,
+          writable: true,
           enumerable: false,
           configurable: true
         });
@@ -201,6 +208,18 @@ describe('AdaptiveRequireHook', () => {
       arc.withFlags({ adapt:true }, () => {
         expect(adaptiveValue).to.eql([4,5,6]);
         expect(Array.isArray(adaptiveValue)).to.equal(true);
+      });
+    });
+    it('should return length as non-configurable', function() {
+      let adaptiveValue = require('./arrays');
+      arc.withFlags({ adapt:true }, () => {
+        const length = Object.getOwnPropertyDescriptor(adaptiveValue, 'length');
+        expect(length).to.eql({
+          value: 3,
+          writable: true,
+          enumerable: false,
+          configurable: false
+        });
       });
     });
   });

--- a/packages/arc-server/test/index.js
+++ b/packages/arc-server/test/index.js
@@ -195,6 +195,16 @@ describe('AdaptiveRequireHook', () => {
     });
   });
 
+  describe('arrays', () => {
+    it('should preserve the array type', function() {
+      let adaptiveValue = require('./arrays');
+      arc.withFlags({ adapt:true }, () => {
+        expect(adaptiveValue).to.eql([4,5,6]);
+        expect(Array.isArray(adaptiveValue)).to.equal(true);
+      });
+    });
+  });
+
   describe('functions', () => {
     it('should resolve adaptive functions', function() {
       let fn = require('./functions');

--- a/packages/arc-server/test/objects/index.js
+++ b/packages/arc-server/test/objects/index.js
@@ -1,1 +1,9 @@
-module.exports = { a: 1, b: 2, c: { hello: 'world', foo: 'bar' } };
+let object = { a: 1, b: 2, c: { hello: 'world', foo: 'bar' } };;
+
+Object.defineProperty(object, 'baz', {
+  value: 123,
+  configurable: true,
+  writable: false
+});
+
+module.exports = object;

--- a/packages/arc-server/test/objects/index[config].js
+++ b/packages/arc-server/test/objects/index[config].js
@@ -10,4 +10,10 @@ Object.defineProperty(object, 'bar', {
   configurable: true
 });
 
+Object.defineProperty(object, 'baz', {
+  value: 3,
+  configurable: false,
+  writable: true
+});
+
 module.exports = object;


### PR DESCRIPTION
This change preserves proxied arrays as actual arrays so that things like `Array.isArray(adaptiveValue)` will work. As it is, arrays get turned into array-like objects because the `length` property is not configurable. Additionally, check the `writable` property when determining if an object needs to be re-created to make it configurable.